### PR TITLE
fix: do not enable socket support in Swoole

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN mkdir -p /tmp/swoole && \
     curl -s -o swoole.tgz https://pecl.php.net/get/$SWOOLEPACKAGE && \
     tar xzvf swoole.tgz --strip-components=1 && \
     phpize && \
-    ./configure --enable-sockets --enable-http2 && \
+    ./configure --enable-http2 && \
     make && \
     make install && \
     cd /tmp && \

--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -16,7 +16,7 @@ RUN mkdir -p /tmp/swoole && \
     curl -s -o swoole.tgz https://pecl.php.net/get/$SWOOLEPACKAGE && \
     tar xzvf swoole.tgz --strip-components=1 && \
     phpize && \
-    ./configure --enable-sockets --enable-http2 && \
+    ./configure --enable-http2 && \
     make && \
     make install && \
     cd /tmp && \


### PR DESCRIPTION
While it compiles, necessary include files are missing that are only
detected at runtime, thus leaving the swoole extension disabled.