### PR TITLE
fix: enable the swoole extension

### DIFF
--- a/swoole.ini
+++ b/swoole.ini
@@ -9,3 +9,4 @@ log_errors = On
 track_errors = Off
 html_errors = Off
 error_log = /proc/self/fd/2
+extension=swoole.so


### PR DESCRIPTION
Updates `swoole.ini` to add the line `extension=swoole.so`, thus
enabling the extension.